### PR TITLE
Add Github Action CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - '.gitignore'
+      - '.gitattributes'
+      - '.gitmodules'
+      - '**/LICENSE'
+      - '**.md'
+
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - '.gitignore'
+      - '.gitattributes'
+      - '.gitmodules'
+      - '**/LICENSE'
+      - '**.md'
+
+  # Manual trigger
+  workflow_dispatch:
+
+env:
+  VAPOURSYNTH_VERSION: R61
+
+jobs:
+  build-linux:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: configure
+        run: |
+          wget https://github.com/vapoursynth/vapoursynth/archive/refs/tags/${{env.VAPOURSYNTH_VERSION}}.tar.gz
+          tar -xzvf ${{env.VAPOURSYNTH_VERSION}}.tar.gz vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include
+          mv vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include/VapourSynth.h AreaResize/VapourSynth.h
+          mv vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include/VSHelper.h AreaResize/VSHelper.h
+
+      - name: build
+        run: g++ -shared -fPIC -O2 AreaResize/AreaResize.cpp -o AreaResize.so
+
+      - name: strip
+        run: strip AreaResize.so
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-vapoursynth-arearesize
+          path: AreaResize.so
+
+  build-windows:
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: configure
+        run:  |
+          curl -s -L https://github.com/vapoursynth/vapoursynth/archive/refs/tags/${{env.VAPOURSYNTH_VERSION}}.tar.gz -o ${{env.VAPOURSYNTH_VERSION}}.tar.gz
+          tar -xzvf ${{env.VAPOURSYNTH_VERSION}}.tar.gz vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include
+          mv vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include/VapourSynth.h AreaResize/VapourSynth.h
+          mv vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include/VSHelper.h AreaResize/VSHelper.h
+
+      - name: build
+        run: x86_64-w64-mingw32-g++ -shared -static -O2 AreaResize/AreaResize.cpp -o AreaResize.dll
+
+      - name: strip
+        run: strip AreaResize.dll
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-vapoursynth-arearesize
+          path: AreaResize.dll

--- a/README.md
+++ b/README.md
@@ -62,3 +62,28 @@ x86_64-w64-mingw32-g++ -shared -o AreaResize.dll -O2 -static AreaResize.cpp
 ```
 g++ -shared -fPIC -O2 AreaResize.cpp -o AreaResize.so
 ```
+
+### Windows and Linux using Github Actions
+
+1.[Fork this repository](https://github.com/Kiyamou/VapourSynth-AreaResize/fork).
+
+2.Enable Github Actions on your fork: **Settings** tab -> **Actions** -> **General** -> **Allow all actions and reusable workflows** -> **Save** button.
+
+3.Edit (if necessary) the file `.github/workflows/CI.yml` on your fork modifying the environment variable VapourSynth version:
+
+```
+env:
+  VAPOURSYNTH_VERSION: <SET_YOUR_VERSION>
+```
+
+4.Go to the GitHub **Actions** tab on your fork, select **CI** workflow and press the **Run workflow** button (if you modified the `.github/workflows/CI.yml` file, a workflow will be already running and no need to run a new one).
+
+When the workflow is completed you will be able to download the artifacts generated (Windows and Linux versions) from the run.
+
+## Download Nightly Builds
+
+**GitHub Actions Artifacts ONLY can be downloaded by GitHub logged users.**
+
+Nightly builds are built automatically by GitHub Actions (GitHub's integrated CI/CD tool) every time a new commit is pushed to the _master_ branch or a pull request is created.
+
+To download the latest nightly build, go to the GitHub [Actions](https://github.com/Kiyamou/VapourSynth-AreaResize/actions/workflows/CI.yml) tab, enter the last run of workflow **CI**, and download the artifacts generated (Windows and Linux versions) from the run.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # VapourSynth-AreaResize
 
+[![Build Status](https://github.com/Kiyamou/VapourSynth-AreaResize/workflows/CI/badge.svg)](https://github.com/Kiyamou/VapourSynth-AreaResize/actions/workflows/CI.yml)
+
 ## Description
 
 AreaResize is an area average downscale resizer plugin for VapourSynth. Support 8-16 bit and 32 bit sample type. Support Gray, YUV and RGB color family.

--- a/README.md
+++ b/README.md
@@ -47,10 +47,18 @@ core.area.AreaResize(clip clip, int width, int height[, float gamma=2.2])
 
 ## Compilation
 
+`VapourSynth.h` and `VSHelper.h` need be in the same folder. You can get them from [here](https://github.com/vapoursynth/vapoursynth/tree/master/include) or your VapourSynth installation directory (`VapourSynth/sdk/include/vapoursynth`).
+
+Make sure the header files used during compilation are the same as those of your VapourSynth installation directory.
+
+### Windows
+
 ```
 x86_64-w64-mingw32-g++ -shared -o AreaResize.dll -O2 -static AreaResize.cpp
 ```
 
-`VapourSynth.h` and `VSHelper.h` need be in the same folder. You can get them from [here](https://github.com/vapoursynth/vapoursynth/tree/master/include) or your VapourSynth installation directory (`VapourSynth/sdk/include/vapoursynth`).
+### Linux
 
-Make sure the header files used during compilation are the same as those of your VapourSynth installation directory.
+```
+g++ -shared -fPIC -O2 AreaResize.cpp -o AreaResize.so
+```


### PR DESCRIPTION
With these changes, GitHub users can compile the latest version using GitHub Actions without install VapourSynth and compilation tools on their computers, getting Linux and Windows libraries with the VapourSynth version of their choice (README is updated with instructions), so it's very easy test the code with different VapourSynth versions.

* No need to compile if text files are changed
* Use VapourSynth R61 headers configurable via environment variable
* Add Linux and Windows builds uploading compiled stripped libraries
* Add manual trigger to test compilation with other branches
* Add GitHub workflow badget in README
* Add Linux compilation in README
* Add GitHub Actions instructions in README

Notes:
* Build status badget isn't shown on my fork because it's using your repository URL and your repository doesn't currently include the Github Action CI workflow, but it will show correctly when you merge this pull request.
* You must enable Github Actions and workflows (if it's not already).